### PR TITLE
feat: add codecov upload step to CI

### DIFF
--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -41,3 +41,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -37,4 +37,7 @@ jobs:
         run: go vet ./...
 
       - name: go test
-        run: go test ./... -postgres-url postgres://postgres:password@localhost:5432 -v
+        run: go test ./... -postgres-url postgres://postgres:password@localhost:5432 -v -cover -covermode=count -coverprofile=coverage.out
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
adds a step to upload a go test coverage report to codecov