### PR TITLE
fix: multiply by 1e9 to set resolution to nanoseconds

### DIFF
--- a/schema/v4.sql
+++ b/schema/v4.sql
@@ -3,7 +3,7 @@
 -- Column keepalive_interval is the interval in seconds at which the worker
 -- is expected to send the pings. Defaults to 30 seconds.
 ALTER TABLE sqlq.jobs
-    ADD COLUMN keepalive_interval BIGINT NOT NULL DEFAULT (30);
+    ADD COLUMN keepalive_interval BIGINT NOT NULL DEFAULT (30 * 1e9);
 
 -- Column last_keepalive stores the last ping's time
 ALTER TABLE sqlq.jobs


### PR DESCRIPTION
This PR fixes a small bug I encountered while implementing auto-import job in mergestat. The default value for `sqlq.jobs.keepalive_interval` is set to `30` seconds. But the `time.Duration` resolution in golang is in nanoseconds. So, we need to multiply by `1e9` to ensure that when the value is read back in Go, we get the right value.