### PR TITLE
feat(process): Adding cancel functionality

### DIFF
--- a/cancellation_test.go
+++ b/cancellation_test.go
@@ -1,0 +1,66 @@
+package sqlq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mergestat/sqlq"
+
+	"github.com/mergestat/sqlq/runtime/embed"
+)
+
+func TestCancelled(t *testing.T) {
+	var err error
+
+	var upstream = MustOpen(PostgresUrl)
+
+	defer upstream.Close()
+
+	job, _ := sqlq.Enqueue(upstream, "embed/cancelled", NewCancelledTask())
+
+	_ = setConcurrencyAndPriority(upstream, "embed/cancelled", 1, 10)
+
+	var worker, _ = embed.NewWorker(upstream, embed.WorkerConfig{
+		Queues: []sqlq.Queue{"embed/cancelled"},
+	})
+
+	_ = worker.Register("notify", cancelledJob())
+
+	if err := worker.Start(); err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	if _, err := upstream.Exec("UPDATE sqlq.jobs SET status ='cancelling' WHERE id = $1", job.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the routine to execute
+	time.Sleep(2 * time.Second)
+	var isCancelled bool
+
+	if isCancelled, err = sqlq.IsCancelled(upstream, job); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isCancelled {
+		t.Fail()
+	}
+
+	if err := worker.Shutdown(5 * time.Second); err != nil {
+		t.Fatalf("failed to shutdown worker: %v", err)
+	}
+}
+
+func NewCancelledTask() *sqlq.JobDescription {
+	return sqlq.NewJobDesc("notify")
+}
+
+func cancelledJob() sqlq.HandlerFunc {
+	return func(ctx context.Context, job *sqlq.Job) error {
+		time.Sleep(10 * time.Second)
+		return nil
+	}
+}

--- a/cancellation_test.go
+++ b/cancellation_test.go
@@ -25,7 +25,7 @@ func TestCancelled(t *testing.T) {
 		Queues: []sqlq.Queue{"embed/cancelled"},
 	})
 
-	_ = worker.Register("notify", cancelledJob())
+	_ = worker.Register("cancelled", cancelledJob())
 
 	if err := worker.Start(); err != nil {
 		t.Fatalf("failed to start worker: %v", err)
@@ -55,7 +55,7 @@ func TestCancelled(t *testing.T) {
 }
 
 func NewCancelledTask() *sqlq.JobDescription {
-	return sqlq.NewJobDesc("notify")
+	return sqlq.NewJobDesc("cancelled")
 }
 
 func cancelledJob() sqlq.HandlerFunc {

--- a/completion_test.go
+++ b/completion_test.go
@@ -1,7 +1,9 @@
 package sqlq_test
 
 import (
+	"database/sql"
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -121,14 +123,31 @@ func TestCancelled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var job *Job
-	if job, err = Dequeue(upstream, []Queue{"test/cancelled"}); err != nil {
+	if _, err = Dequeue(upstream, []Queue{"test/cancelled"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := upstream.Exec("UPDATE sqlq.jobs SET status ='cancelling' WHERE typename = $1", "test/cancelled"); err != nil {
 		t.Fatal(err)
 	}
 
-	time.Sleep(job.KeepAlive) // wait for the keepalive time to pass
+	{
+		time.After(5 * time.Second)
+		var res *sql.Rows
 
+		if res, err = upstream.Query("SELECT * FROM sqlq.jobs WHERE status = 'cancelling'"); err != nil {
+			t.Fatal(err)
+		}
+		var cancelledJob *Job
+
+		if res.Next() {
+			if err = res.Scan(&cancelledJob); err != nil {
+				t.Fatalf("failed to scan rows")
+
+			}
+		}
+
+		if reflect.DeepEqual(cancelledJob, Job{}) {
+			t.Errorf("Failed to pickup cancelling jobs")
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mergestat/sqlq
 go 1.16
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/job.go
+++ b/job.go
@@ -61,6 +61,10 @@ func (i *JobState) Scan(src interface{}) error {
 			*i = StateSuccess
 		case "errored":
 			*i = StateErrored
+		case "cancelling":
+			*i = StateCancelling
+		case "cancelled":
+			*i = StateCancelled
 		default:
 			*i = StateInvalid
 		}
@@ -69,11 +73,13 @@ func (i *JobState) Scan(src interface{}) error {
 }
 
 const (
-	StateInvalid JobState = iota // invalid
-	StatePending                 // pending
-	StateRunning                 // running
-	StateSuccess                 // success
-	StateErrored                 // errored
+	StateInvalid    JobState = iota // invalid
+	StatePending                    // pending
+	StateRunning                    // running
+	StateSuccess                    // success
+	StateErrored                    // errored
+	StateCancelling                 // cancelling
+	StateCancelled                  // cancelled
 )
 
 // JobDescription describes a job to be enqueued. Note that it is just a set of options (that closely resembles) for a job,

--- a/job.go
+++ b/job.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -124,11 +125,11 @@ func WithKeepAlive(n time.Duration) func(*JobDescription) {
 
 // Job represents an instance of a task / job in a queue.
 type Job struct {
-	ID       int      `db:"id"`
-	Queue    Queue    `db:"queue"`
-	TypeName string   `db:"typename"`
-	Priority int      `db:"priority"`
-	Status   JobState `db:"status"`
+	ID       uuid.UUID `db:"id"`
+	Queue    Queue     `db:"queue"`
+	TypeName string    `db:"typename"`
+	Priority int       `db:"priority"`
+	Status   JobState  `db:"status"`
 
 	Parameters []byte `db:"parameters"`
 	Result     []byte `db:"result"`

--- a/job_state.go
+++ b/job_state.go
@@ -13,11 +13,13 @@ func _() {
 	_ = x[StateRunning-2]
 	_ = x[StateSuccess-3]
 	_ = x[StateErrored-4]
+	_ = x[StateCancelling-5]
+	_ = x[StateCancelled-6]
 }
 
-const _JobState_name = "invalidpendingrunningsuccesserrored"
+const _JobState_name = "invalidpendingrunningsuccesserroredcancellingcancelled"
 
-var _JobState_index = [...]uint8{0, 7, 14, 21, 28, 35}
+var _JobState_index = [...]uint8{0, 7, 14, 21, 28, 35, 45, 54}
 
 func (i JobState) String() string {
 	if i >= JobState(len(_JobState_index)-1) {

--- a/runtime/embed/embed.go
+++ b/runtime/embed/embed.go
@@ -6,11 +6,12 @@ package embed
 
 import (
 	"database/sql"
-	"github.com/mergestat/sqlq"
-	"github.com/pkg/errors"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/mergestat/sqlq"
+	"github.com/pkg/errors"
 )
 
 type WorkerConfig struct {

--- a/runtime/embed/logger.go
+++ b/runtime/embed/logger.go
@@ -2,16 +2,18 @@ package embed
 
 import (
 	"database/sql"
-	"github.com/mergestat/sqlq"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/mergestat/sqlq"
 )
 
 // logger returns a new instance of a sqlq.LogBackend
 func logger(db *sql.DB) (sqlq.LogBackendAdapter, func() error) {
 	// event is the type of the payload shared on the internal buffer channel
 	type event = struct {
-		job   int
+		job   uuid.UUID
 		level sqlq.LogLevel
 		msg   string
 	}

--- a/runtime/embed/process.go
+++ b/runtime/embed/process.go
@@ -132,7 +132,7 @@ func process(worker *Worker, loggingBackend sqlq.LogBackend) (shutdown func(time
 						if err = sqlq.Cancelled(worker.db, job); err != nil {
 							log.Printf("failed to mark job as cancelled: %#v", err)
 						}
-						// We need cancel the context after mark the job  as cancelled, otherwise it'd would
+						// We need to cancel the context after marking the job as cancelled, otherwise it would
 						// cause the user's routine to return an error which would then mark the job as errored rather than cancelled
 						cancel()
 

--- a/runtime/embed/process.go
+++ b/runtime/embed/process.go
@@ -108,7 +108,7 @@ func process(worker *Worker, loggingBackend sqlq.LogBackend) (shutdown func(time
 							}
 							defer func() { _ = tx.Rollback() }()
 
-							if rows, err = sqlq.Cancelling(tx, job); err != nil {
+							if rows, err = sqlq.Cancelled(tx, job); err != nil {
 								return 0, err
 							}
 
@@ -116,7 +116,9 @@ func process(worker *Worker, loggingBackend sqlq.LogBackend) (shutdown func(time
 							return rows, err
 						}
 
+						//lint:ignore S1000 we want to make sure we use a for loop instead a for range loop
 						for {
+							//lint:ignore S1037 we don't want to sleep the context, instead we want to wait 3 seconds for this to execute
 							select {
 							case <-time.After(3 * time.Second):
 								var rows int64

--- a/schema/v1.sql
+++ b/schema/v1.sql
@@ -18,7 +18,7 @@ CREATE TABLE sqlq.queues
 -- Table: sqlq.job_states
 -- Jobs states is an enumeration of all possible states a job can be in.
 -- It is used to implement a job's state machine.
-CREATE TYPE sqlq.job_states AS ENUM ('pending', 'running', 'success', 'errored','cancelling','cancelled');
+CREATE TYPE sqlq.job_states AS ENUM ('pending', 'running', 'success', 'errored');
 
 -- Table: sqlq.jobs
 -- Jobs represent a job / task to execute in background, asynchronously. Jobs are enqueued to a queue

--- a/schema/v1.sql
+++ b/schema/v1.sql
@@ -18,7 +18,7 @@ CREATE TABLE sqlq.queues
 -- Table: sqlq.job_states
 -- Jobs states is an enumeration of all possible states a job can be in.
 -- It is used to implement a job's state machine.
-CREATE TYPE sqlq.job_states AS ENUM ('pending', 'running', 'success', 'errored');
+CREATE TYPE sqlq.job_states AS ENUM ('pending', 'running', 'success', 'errored','cancelling','cancelled');
 
 -- Table: sqlq.jobs
 -- Jobs represent a job / task to execute in background, asynchronously. Jobs are enqueued to a queue

--- a/schema/v6.sql
+++ b/schema/v6.sql
@@ -36,7 +36,7 @@ $$ LANGUAGE SQL;
 -- Function: sqlq.mark_success
 --
 -- SQLQ.MARK_SUCCESS() transitions the job to 'success' state and mark it as completed.
-CREATE FUNCTION sqlq.mark_success(id INTEGER, expectedState SQLQ.JOB_STATES)
+CREATE FUNCTION sqlq.mark_success(id UUID, expectedState SQLQ.JOB_STATES)
 RETURNS SETOF sqlq.jobs AS $$
 BEGIN
     RETURN QUERY UPDATE sqlq.jobs SET status = 'success', completed_at = NOW()
@@ -49,7 +49,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 --
 -- SQLQ.MARK_FAILED() transitions the job to ERROR state and mark it as completed. If the error is retryable
 -- (and there are still attempts left), we transition it to PENDING to be picked up again by a worker.
-CREATE FUNCTION sqlq.mark_failed(id INTEGER, expectedState SQLQ.JOB_STATES, retry BOOLEAN = false, run_after BIGINT = 0)
+CREATE FUNCTION sqlq.mark_failed(id UUID, expectedState SQLQ.JOB_STATES, retry BOOLEAN = false, run_after BIGINT = 0)
 RETURNS SETOF sqlq.jobs AS $$
 BEGIN
     IF retry THEN

--- a/schema/v7.sql
+++ b/schema/v7.sql
@@ -1,0 +1,20 @@
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+BEGIN;
+ALTER TABLE sqlq.job_logs
+DROP COLUMN job;
+
+ALTER TABLE sqlq.jobs
+DROP COLUMN id;
+
+ALTER TABLE sqlq.jobs
+ADD COLUMN id uuid PRIMARY KEY DEFAULT public.gen_random_uuid() NOT NULL;
+
+ALTER TABLE sqlq.job_logs
+ADD COLUMN job  uuid DEFAULT public.gen_random_uuid() NOT NULL;
+
+AlTER TABLE sqlq.job_logs
+ADD CONSTRAINT job FOREIGN KEY (job) REFERENCES sqlq.jobs (id) ON DELETE CASCADE;
+
+COMMIT;

--- a/schema/v7.sql
+++ b/schema/v7.sql
@@ -1,4 +1,5 @@
-
+-- Migration to change  jobs primary key to UUID and all tables dependant of it.
+-- We create an extension to use a random UUID as default each time we create the column.
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 BEGIN;

--- a/schema/v8.sql
+++ b/schema/v8.sql
@@ -1,0 +1,3 @@
+-- Migration to alter the type of sqlq.job_states.
+ALTER TYPE sqlq.job_states ADD VALUE 'cancelling';
+ALTER TYPE sqlq.job_states ADD VALUE 'cancelled';

--- a/schema/v9.sql
+++ b/schema/v9.sql
@@ -1,0 +1,30 @@
+-- Migration to add utility function
+
+-- Function: sqlq.check_job_status
+--
+-- SQLQ.CHECK_JOB_STATUS(JOB_ID, STATE) checks if the job is in
+-- a specific state.
+CREATE FUNCTION sqlq.check_job_status(job_id UUID, state sqlq.job_states)
+RETURNS BOOLEAN AS $$
+BEGIN
+    IF EXISTS(SELECT COUNT(*) FROM sqlq.jobs WHERE id = job_id AND status = state) THEN 
+       RETURN TRUE;
+    ELSE
+       RETURN FALSE;
+    END IF;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+
+-- Function: sqlq.cancelling_job
+--
+-- SQLQ.CANCELLING_JOB(JOB_ID) change the state of a running or pending job to cancelling.
+CREATE FUNCTION sqlq.cancelling_job(job_id UUID)
+RETURNS sqlq.job_states as $$
+  UPDATE sqlq.jobs 
+        SET status = 'cancelling'
+   WHERE id = job_id AND status = 'running' OR status ='pending'
+        RETURNING status;
+$$ LANGUAGE SQL;
+
+

--- a/sqlq.go
+++ b/sqlq.go
@@ -168,6 +168,23 @@ retry:
 	return &job, nil
 }
 
+func Cancelling(cx Connection, job *Job) (n int64, err error) {
+	var ctx = context.Background()
+	var res sql.Result
+
+	const cancelJob = `
+	UPDATE sqlq.jobs
+		SET status = 'cancelled',
+		completed_at = NOW()
+	WHERE id =$1 AND status = 'cancelling'`
+
+	if res, err = cx.ExecContext(ctx, cancelJob, job.ID); err != nil {
+		return 0, errors.Wrapf(err, "failed to executed cancel operation")
+	}
+
+	return res.RowsAffected()
+}
+
 // Success transitions the job to SUCCESS state and mark it as completed.
 func Success(cx Connection, job *Job) (err error) {
 	var ctx = context.Background()

--- a/sqlq.go
+++ b/sqlq.go
@@ -168,7 +168,8 @@ retry:
 	return &job, nil
 }
 
-func Cancelling(cx Connection, job *Job) (n int64, err error) {
+// Cancelled transitions the job to CANCELLED state and mark it as completed
+func Cancelled(cx Connection, job *Job) (n int64, err error) {
 	var ctx = context.Background()
 	var res sql.Result
 


### PR DESCRIPTION
This the first implementation of the cancel functionality on the sqlq lib. We do a polling pattern checking the status of the current job every 3 second(this number can change) looking for a cancelling status , if we found one we change it status to cancelled and exits the context of the current job.
Closes #28 