### PR TITLE
fix(migrations): Refactoring migrations to be idempotent and our handling of trasactions

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -39,7 +39,7 @@ func Apply(c *sql.DB) (err error) {
 			continue // already applied. skip this migration
 		}
 
-		if err = applyMigrations(c, mg); err != nil {
+		if err = applyMigration(c, mg); err != nil {
 			return errors.Wrapf(err, "failed to apply migration: name=%s\tversion=%d", mg.Name(), mg.Version())
 		}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -4,8 +4,9 @@ package schema
 import (
 	"database/sql"
 	"embed"
-	"github.com/pkg/errors"
 	"sort"
+
+	"github.com/pkg/errors"
 )
 
 //go:embed *.sql
@@ -19,7 +20,68 @@ func setup(tx *sql.Tx) error {
 
 // Apply applies any pending schema migration on the database.
 func Apply(c *sql.DB) (err error) {
+
+	if err = applySetup(c); err != nil {
+		return err
+	}
+
+	var migrations = ReadMigrations(root)
+	sort.Stable(migrations) // sort in ascending order of version number
+
+	var currentVersion = 0
+	if currentVersion, err = getCurrentMigrationVersion(c); err != nil {
+		return err
+	}
+
+	for _, mg := range migrations {
+
+		if mg.Version() <= currentVersion {
+			continue // already applied. skip this migration
+		}
+
+		if err = applyMigrations(c, mg); err != nil {
+			return errors.Wrapf(err, "failed to apply migration: name=%s\tversion=%d", mg.Name(), mg.Version())
+		}
+
+	}
+
+	return nil
+}
+
+// getCurrentMigrationVersion gets the current version of our migrations
+func getCurrentMigrationVersion(c *sql.DB) (int, error) {
+	const fetchCurrentVersion = "SELECT version FROM sqlq_migrations ORDER BY applied_on DESC, version DESC LIMIT 1"
+	var currentVersion int
+	var err error
 	var tx *sql.Tx
+	var rows *sql.Rows
+
+	if tx, err = c.Begin(); err != nil {
+		return 0, errors.Wrapf(err, "failed to start new transaction")
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if rows, err = tx.Query(fetchCurrentVersion); err != nil && err != sql.ErrNoRows {
+		return 0, errors.Wrap(err, "failed to fetch latest migration version")
+	}
+
+	if rows.Next() {
+		if err = rows.Scan(&currentVersion); err != nil && err != sql.ErrNoRows {
+			return 0, errors.Wrap(err, "failed to fetch latest migration version")
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return 0, errors.Wrap(err, "failed to iterate rows")
+	}
+
+	return currentVersion, errors.Wrapf(tx.Commit(), "failed commit getting current migration version")
+}
+
+// applySetup creates if needed a migrations table
+func applySetup(c *sql.DB) error {
+	var tx *sql.Tx
+	var err error
 	if tx, err = c.Begin(); err != nil {
 		return errors.Wrapf(err, "failed to start new transaction")
 	}
@@ -28,40 +90,28 @@ func Apply(c *sql.DB) (err error) {
 	if err = setup(tx); err != nil {
 		return errors.Wrapf(err, "failed to perform setup")
 	}
+	return errors.Wrapf(tx.Commit(), "failed to commit setup")
+}
 
-	var migrations = ReadMigrations(root)
-	sort.Stable(migrations) // sort in ascending order of version number
+// applyMigrations is responsible  for apply a migration individually
+func applyMigrations(c *sql.DB, mg *EmbeddedMigration) error {
+	var tx *sql.Tx
+	var err error
+	if tx, err = c.Begin(); err != nil {
+		return errors.Wrapf(err, "failed to start new transaction")
+	}
+	defer func() { _ = tx.Rollback() }()
 
-	var currentVersion = 0
-	const fetchCurrentVersion = "SELECT version FROM sqlq_migrations ORDER BY applied_on DESC, version DESC LIMIT 1"
-
-	var rows *sql.Rows
-	if rows, err = tx.Query(fetchCurrentVersion); err != nil && err != sql.ErrNoRows {
-		return errors.Wrap(err, "failed to fetch latest migration version")
+	if err = mg.Apply(tx); err != nil {
+		return errors.Wrapf(err, "failed to apply migration(%s)", mg.Name())
 	}
 
-	if rows.Next() {
-		if err = rows.Scan(&currentVersion); err != nil && err != sql.ErrNoRows {
-			return errors.Wrap(err, "failed to fetch latest migration version")
-		}
+	const recordMigration = "INSERT INTO sqlq_migrations(name, version) VALUES ($1, $2)"
+
+	if _, err = tx.Exec(recordMigration, mg.Name(), mg.Version()); err != nil {
+		return errors.Wrapf(err, "failed to record migration: name=%s\tversion=%d", mg.Name(), mg.Version())
 	}
-
-	for _, mg := range migrations {
-		if mg.Version() <= currentVersion {
-			continue // already applied. skip this migration
-		}
-
-		if err = mg.Apply(tx); err != nil {
-			return errors.Wrapf(err, "failed to apply migration(%s)", mg.Name())
-		}
-
-		const recordMigration = "INSERT INTO sqlq_migrations(name, version) VALUES ($1, $2)"
-		if _, err = tx.Exec(recordMigration, mg.Name(), mg.Version()); err != nil {
-			return errors.Wrapf(err, "failed to record migration: name=%s\tversion=%d", mg.Name(), mg.Version())
-		}
-	}
-
-	return errors.Wrapf(tx.Commit(), "failed to commit migration")
+	return errors.Wrapf(tx.Commit(), "failed to commit migrations")
 }
 
 // Teardown tears down the sql migrations and drop the default schema

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -28,8 +28,8 @@ func Apply(c *sql.DB) (err error) {
 	var migrations = ReadMigrations(root)
 	sort.Stable(migrations) // sort in ascending order of version number
 
-	var currentVersion = 0
-	currentVersion, err = getCurrentMigrationVersion(c)
+	//var currentVersion = 0
+	currentVersion, err := getCurrentMigrationVersion(c)
 	if err != nil {
 		return err
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -28,7 +28,6 @@ func Apply(c *sql.DB) (err error) {
 	var migrations = ReadMigrations(root)
 	sort.Stable(migrations) // sort in ascending order of version number
 
-	//var currentVersion = 0
 	currentVersion, err := getCurrentMigrationVersion(c)
 	if err != nil {
 		return err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -87,8 +87,8 @@ func applySetup(c *sql.DB) error {
 	return errors.Wrapf(tx.Commit(), "failed to commit setup")
 }
 
-// applyMigrations is responsible  for apply a migration individually
-func applyMigrations(c *sql.DB, mg *EmbeddedMigration) error {
+// applyMigration applies a single embedded migration to the database
+func applyMigration(c *sql.DB, mg *EmbeddedMigration) error {
 	var tx *sql.Tx
 	var err error
 	if tx, err = c.Begin(); err != nil {

--- a/schema/v7.sql
+++ b/schema/v7.sql
@@ -6,8 +6,6 @@
 -- recreate them with the UUID changes .
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-BEGIN;
-
 -- Dropping the tables also drops the associated functions 
 DROP TABLE IF EXISTS sqlq.jobs CASCADE;
 DROP TABLE IF EXISTS sqlq.job_logs CASCADE;
@@ -132,5 +130,3 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
-
-COMMIT;

--- a/schema/v8.sql
+++ b/schema/v8.sql
@@ -1,3 +1,3 @@
 -- Migration to alter the type of sqlq.job_states.
-ALTER TYPE sqlq.job_states ADD VALUE 'cancelling';
-ALTER TYPE sqlq.job_states ADD VALUE 'cancelled';
+ALTER TYPE sqlq.job_states ADD VALUE IF NOT EXISTS 'cancelling';
+ALTER TYPE sqlq.job_states ADD VALUE IF NOT EXISTS 'cancelled';

--- a/schema/v9.sql
+++ b/schema/v9.sql
@@ -4,9 +4,9 @@
 --
 -- SQLQ.CHECK_JOB_STATUS(JOB_ID, STATE) checks if the job is in
 -- a specific state.
-CREATE FUNCTION sqlq.check_job_status(job_id UUID, state sqlq.job_states)
+CREATE OR REPLACE FUNCTION sqlq.check_job_status(job_id UUID, state sqlq.job_states)
 RETURNS BOOLEAN AS $$
-BEGIN
+BEGIN 
     IF EXISTS(SELECT COUNT(*) FROM sqlq.jobs WHERE id = job_id AND status = state) THEN 
        RETURN TRUE;
     ELSE
@@ -19,7 +19,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 -- Function: sqlq.cancelling_job
 --
 -- SQLQ.CANCELLING_JOB(JOB_ID) change the state of a running or pending job to cancelling.
-CREATE FUNCTION sqlq.cancelling_job(job_id UUID)
+CREATE OR REPLACE FUNCTION sqlq.cancelling_job(job_id UUID)
 RETURNS sqlq.job_states as $$
   UPDATE sqlq.jobs 
         SET status = 'cancelling'

--- a/schema/v9.sql
+++ b/schema/v9.sql
@@ -6,7 +6,7 @@
 -- a specific state.
 CREATE OR REPLACE FUNCTION sqlq.check_job_status(job_id UUID, state sqlq.job_states)
 RETURNS BOOLEAN AS $$
-BEGIN 
+BEGIN
     IF EXISTS(SELECT COUNT(*) FROM sqlq.jobs WHERE id = job_id AND status = state) THEN 
        RETURN TRUE;
     ELSE


### PR DESCRIPTION
To test this:
- docker-compose down -v
- docker-compose up -d
- go test ./... -postgres-url postgres://postgres:password@localhost:5432 -v
- then delete registry of migrations from v9 to v6  and rerun ./... -postgres-url postgres://postgres:password@localhost:5432 -v