### PR TITLE
fix(db): Closing connections after usage

### DIFF
--- a/cancellation_test.go
+++ b/cancellation_test.go
@@ -69,19 +69,17 @@ func cancelledJob() sqlq.HandlerFunc {
 
 func Waiter(wg *sync.WaitGroup) sqlq.HandlerFunc {
 	return func(ctx context.Context, job *sqlq.Job) error {
-		select {
-		case <-time.After(10 * time.Second):
-			wg.Done()
-			return errors.New("test")
-		}
+		<-time.After(10 * time.Second)
+		wg.Done()
+		return errors.New("test")
 	}
 }
 
 func TestLeak(t *testing.T) {
 	var upstream = MustOpen(PostgresUrl)
+
 	defer upstream.Close()
 
-	//upstream.SetMaxOpenConns(2)
 	t.Logf("stats: %+v", upstream.Stats())
 	var wg sync.WaitGroup
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -59,6 +59,8 @@ func getCurrentMigrationVersion(c *sql.DB) (int, error) {
 		return 0, errors.Wrap(err, "failed to fetch latest migration version")
 	}
 
+	defer func() { _ = rows.Close() }()
+
 	if rows.Next() {
 		if err = rows.Scan(&currentVersion); err != nil && err != sql.ErrNoRows {
 			return 0, errors.Wrap(err, "failed to fetch latest migration version")


### PR DESCRIPTION
There is a significant difference of open connections without  the explicit close  function  from 62 to 2 open connections with the test 
without changes
![screen_shot_2023-02-20_at_11 36 12_am_720](https://user-images.githubusercontent.com/43893061/220169339-2acfca98-94d8-4101-a543-dd2c357ebd5c.png)
With the changes
![screen_shot_2023-02-20_at_11 40 23_am_720](https://user-images.githubusercontent.com/43893061/220169346-76e57d5a-0626-40f1-bea6-351c3cf35625.png)
