### PR TITLE
fix: fix regression in sqlq.reap() introduced by dynamic queues

### DIFF
--- a/reaper_test.go
+++ b/reaper_test.go
@@ -34,6 +34,33 @@ func TestReap(t *testing.T) {
 	}
 }
 
+func TestReapAll(t *testing.T) {
+	var upstream = MustOpen(PostgresUrl)
+	defer upstream.Close()
+
+	var err error
+	var jd = NewJobDesc("blocker", WithMaxRetries(2), WithKeepAlive(2*time.Second))
+	if _, err = Enqueue(upstream, "test/reaper", jd); err != nil {
+		t.Fatalf("failed to enqueue: %#v", err)
+	}
+
+	var job *Job
+	if job, err = Dequeue(upstream, []Queue{"test/reaper"}, WithTypeName([]string{"blocker"})); err != nil {
+		t.Fatalf("failed to dequeue: %#v", err)
+	}
+
+	time.Sleep(job.KeepAlive) // wait for the keepalive time to pass
+
+	var n int64
+	if n, err = Reap(upstream, nil); err != nil {
+		t.Fatalf("failed to reap zombie processes: %#v", err)
+	}
+
+	if n != 1 {
+		t.Fatalf("was expecting to reap %d job(s); reaped %d job(s)", 1, n)
+	}
+}
+
 func TestJobPinger(t *testing.T) {
 	var upstream = MustOpen(PostgresUrl)
 	defer upstream.Close()

--- a/schema/v12.sql
+++ b/schema/v12.sql
@@ -1,0 +1,24 @@
+-- SQL migration to update sqlq.reap routine and make queues filter optional
+
+-- Function: sqlq.reap()
+--
+-- SQLQ.REAP() reaps any zombie process, processes where state is 'running' but the job hasn't pinged in a while (determined by the `keepalive_interval` defined on the job), in the given queues.
+-- It moves any job with remaining attempts back to the queue while dumping all others in to the errored state.
+CREATE OR REPLACE FUNCTION sqlq.reap(queues TEXT[]) RETURNS integer AS $$
+DECLARE
+    count INTEGER;
+BEGIN
+    WITH dead AS (
+        SELECT id, attempt, max_retries FROM sqlq.jobs
+        WHERE status = 'running'
+          AND (ARRAY_LENGTH($1, 1) IS NULL OR queue = ANY($1))
+          AND (NOW() > last_keepalive + make_interval(secs => keepalive_interval / 1e9))
+    )
+    UPDATE sqlq.jobs
+    SET status = (CASE WHEN dead.attempt < dead.max_retries THEN 'pending'::sqlq.job_states ELSE 'errored'::sqlq.job_states END)
+    FROM dead WHERE jobs.id = dead.id;
+
+    GET DIAGNOSTICS count = ROW_COUNT;
+    RETURN count;
+END;
+$$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This PR fixes a regression introduced by the recent "dynamic queue" change.

Fixes: mergestat/internal#148