### PR TITLE
fix: dequeue priority order

### DIFF
--- a/dequeue_test.go
+++ b/dequeue_test.go
@@ -2,11 +2,12 @@ package sqlq_test
 
 import (
 	"database/sql"
-	. "github.com/mergestat/sqlq"
-	"github.com/pkg/errors"
 	"sync"
 	"testing"
 	"time"
+
+	. "github.com/mergestat/sqlq"
+	"github.com/pkg/errors"
 )
 
 func setConcurrencyAndPriority(db *sql.DB, queue Queue, c, p int) error {
@@ -29,7 +30,7 @@ func TestDequeue(t *testing.T) {
 		}
 	}
 
-	if err := setConcurrencyAndPriority(upstream, "critical", 1, 10); err != nil {
+	if err := setConcurrencyAndPriority(upstream, "critical", 1, 0); err != nil {
 		t.Fatalf("failed to update queue concurrency: %v", err)
 	}
 

--- a/schema/v14.sql
+++ b/schema/v14.sql
@@ -1,0 +1,34 @@
+-- SQL migration to update sqlq.dequeue_job to process priority in ascending order
+
+-- Function: sqlq.dequeue_job()
+--
+-- SQLQ.DEQUEUE_JOB() dequeues a job from one of the given queues, in a way that respects individual queues' concurrency.
+-- It dequeues a job and move it to the 'running' state (also updating other relevant fields).
+--
+-- The function can result in a serialization error if run with REPEATABLE READ / SERIALIZABLE isolation level, if two
+-- concurrent processes try to dequeue from the same queues at the same time. This is to protect the queues' concurrency guarantees.
+CREATE OR REPLACE FUNCTION sqlq.dequeue_job(queues TEXT[], jobTypes TEXT[]) RETURNS SETOF sqlq.jobs AS $$
+WITH queues AS (
+    SELECT name, concurrency, priority FROM sqlq.queues WHERE (ARRAY_LENGTH($1, 1) IS NULL OR name = ANY($1))
+), running (name, count) AS (
+    SELECT queue, COUNT(*) FROM sqlq.jobs, queues
+    WHERE jobs.queue = queues.name AND status = 'running'
+    GROUP BY queue
+), queue_with_capacity AS (
+    SELECT queues.name, queues.priority FROM queues LEFT OUTER JOIN running USING(name)
+    WHERE (concurrency IS NULL OR (concurrency - COALESCE(running.count, 0) > 0))
+), dequeued(id) AS (
+    SELECT job.id FROM sqlq.jobs job, queue_with_capacity q
+    WHERE job.status = 'pending'
+      AND (job.last_queued_at+make_interval(secs => job.run_after/1e9)) <= NOW() -- value in run_after is stored as nanoseconds
+      AND job.queue = q.name
+      AND (ARRAY_LENGTH($2, 1) IS NULL OR job.typename = ANY($2))
+    ORDER BY q.priority ASC, job.priority ASC, job.created_at ASC
+    LIMIT 1
+)
+UPDATE sqlq.jobs
+SET status = 'running', started_at = NOW(), last_keepalive = NOW(), attempt = attempt + 1
+FROM dequeued dq
+WHERE jobs.id = dq.id
+RETURNING jobs.*
+$$ LANGUAGE SQL;


### PR DESCRIPTION
changing priority on dequeue to be ASC to match our historical use of using lower numbers as higher priority.